### PR TITLE
Pulled out webp encoding to change implementation

### DIFF
--- a/Commands/DownloadGoogleBinaries.php
+++ b/Commands/DownloadGoogleBinaries.php
@@ -35,14 +35,11 @@ class DownloadGoogleBinaries extends ShopwareCommand
             return 1;
         }
 
-        $url = '';
         $packageDirectory = '';
 
         if ($this->isLinux()) {
-            $url = 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.0.1-linux-x86-64.tar.gz';
             $packageDirectory = 'libwebp-1.0.1-linux-x86-64';
         } else if ($this->isMac()) {
-            $url = 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.0.1-mac-10.13.tar.gz';
             $packageDirectory = 'libwebp-1.0.1-mac-10.13';
         } else {
             $style->error('Downloading binaries is supported for linux and mac only');
@@ -50,7 +47,7 @@ class DownloadGoogleBinaries extends ShopwareCommand
         }
 
         $downloadedPackage = tempnam(sys_get_temp_dir(), 'libwebp') . '.tar.gz';
-
+        $url = 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/' . $packageDirectory . '.tar.gz';
         copy($url, $downloadedPackage);
 
         if (!file_exists($downloadedPackage)) {
@@ -66,6 +63,7 @@ class DownloadGoogleBinaries extends ShopwareCommand
 
         $this->clearDirectory($downloadDir);
         $package->extractTo($downloadDir);
+        unlink($downloadedPackage);
 
         if (!file_exists($cwebpPath)) {
             $style->error('Downloaded package does not contain a cwebp executable');

--- a/Commands/DownloadGoogleBinaries.php
+++ b/Commands/DownloadGoogleBinaries.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace ShyimWebP\Commands;
+
+use Phar;
+use PharData;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Shopware\Commands\ShopwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DownloadGoogleBinaries extends ShopwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('shyim:webp:download-google-binaries')
+            ->setDescription('Downloads google binaries that can convert images to webp')
+        ;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $style = new SymfonyStyle($input, $output);
+
+        if (!$this->is64bit()) {
+            $style->error('There are no binaries for non-64-bit systems');
+            return 1;
+        }
+
+        $url = '';
+        $packageDirectory = '';
+
+        if ($this->isLinux()) {
+            $url = 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.0.1-linux-x86-64.tar.gz';
+            $packageDirectory = 'libwebp-1.0.1-linux-x86-64';
+        } else if ($this->isMac()) {
+            $url = 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.0.1-mac-10.13.tar.gz';
+            $packageDirectory = 'libwebp-1.0.1-mac-10.13';
+        } else {
+            $style->error('Downloading binaries is supported for linux and mac only');
+            return 2;
+        }
+
+        $downloadedPackage = tempnam(sys_get_temp_dir(), 'libwebp') . '.tar.gz';
+
+        copy($url, $downloadedPackage);
+
+        if (!file_exists($downloadedPackage)) {
+            $style->error('Downloading package failed');
+            return 3;
+        }
+
+        $pluginDir = $this->container->getParameter('shyim_web_p.plugin_dir');
+        $cacheDownloadDir = $this->container->getParameter('shyim_web_p.cached_download_dir');
+        $downloadDir = $pluginDir . DIRECTORY_SEPARATOR . '.download';
+        $cwebpPath = $downloadDir . DIRECTORY_SEPARATOR . $packageDirectory . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'cwebp';
+        $package = new PharData($downloadedPackage, null, null, Phar::TAR | Phar::GZ);
+
+        $this->clearDirectory($downloadDir);
+        $package->extractTo($downloadDir);
+
+        if (!file_exists($cwebpPath)) {
+            $style->error('Downloaded package does not contain a cwebp executable');
+            return 4;
+        }
+
+        $this->clearDirectory($cacheDownloadDir);
+        rename($downloadDir . DIRECTORY_SEPARATOR . $packageDirectory, $cacheDownloadDir);
+        $this->clearDirectory($downloadDir);
+
+        return 0;
+    }
+
+    protected function isLinux()
+    {
+        return strtolower(php_uname('s')) === 'linux';
+    }
+
+    protected function isMac()
+    {
+        return strtolower(php_uname('s')) === 'darwin';
+    }
+
+    protected function is64bit()
+    {
+        return strpos(php_uname('m'), '64') !== false;
+    }
+
+    protected function clearDirectory($directory)
+    {
+        if (file_exists($directory)) {
+            $it = new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS);
+            $files = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
+
+            foreach ($files as $file) {
+                if ($file->isDir()){
+                    rmdir($file->getRealPath());
+                } else {
+                    unlink($file->getRealPath());
+                }
+            }
+
+            rmdir($directory);
+        }
+    }
+}

--- a/Commands/DownloadGoogleBinaries.php
+++ b/Commands/DownloadGoogleBinaries.php
@@ -55,9 +55,8 @@ class DownloadGoogleBinaries extends ShopwareCommand
             return 3;
         }
 
-        $pluginDir = $this->container->getParameter('shyim_web_p.plugin_dir');
         $cacheDownloadDir = $this->container->getParameter('shyim_web_p.cached_download_dir');
-        $downloadDir = $pluginDir . DIRECTORY_SEPARATOR . '.download';
+        $downloadDir = $downloadedPackage . '.d';
         $cwebpPath = $downloadDir . DIRECTORY_SEPARATOR . $packageDirectory . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'cwebp';
         $package = new PharData($downloadedPackage, null, null, Phar::TAR | Phar::GZ);
 

--- a/Commands/GenerateWebpImages.php
+++ b/Commands/GenerateWebpImages.php
@@ -47,6 +47,11 @@ class GenerateWebpImages extends ShopwareCommand
 
             try {
                 $im = imagecreatefromstring($this->container->get('shopware_media.media_service')->read($item['path']));
+
+                if ($im === false) {
+                    throw new \Exception('Could not load image');
+                }
+
                 imagepalettetotruecolor($im);
                 $content = $runnableEncoders[0]->encode($im, 80);
                 imagedestroy($im);

--- a/Commands/GenerateWebpImages.php
+++ b/Commands/GenerateWebpImages.php
@@ -53,7 +53,7 @@ class GenerateWebpImages extends ShopwareCommand
                 }
 
                 imagepalettetotruecolor($im);
-                $content = $runnableEncoders[0]->encode($im, 80);
+                $content = current($runnableEncoders)->encode($im, 80);
                 imagedestroy($im);
                 $this->container->get('shopware_media.media_service')->write($webpPath, $content);
             } catch (\Exception $e) {

--- a/Components/Thumbnail/Generator/WebPGenerator.php
+++ b/Components/Thumbnail/Generator/WebPGenerator.php
@@ -1,12 +1,13 @@
 <?php
 
-
 namespace ShyimWebP\Components\Thumbnail\Generator;
 
 use Shopware\Bundle\MediaBundle\Exception\OptimizerNotFoundException;
 use Shopware\Bundle\MediaBundle\MediaServiceInterface;
 use Shopware\Bundle\MediaBundle\OptimizerServiceInterface;
 use Shopware\Components\Thumbnail\Generator\GeneratorInterface;
+use ShyimWebP\Components\WebpEncoderInterface;
+use ShyimWebP\Services\WebpEncoderFactory;
 
 class WebPGenerator implements GeneratorInterface
 {
@@ -25,16 +26,28 @@ class WebPGenerator implements GeneratorInterface
      */
     private $optimizerService;
 
+    /** @var WebpEncoderFactory */
+    private $webpEncoderFactory;
+
+    /** @var WebpEncoderInterface[] */
+    private $webpEncoders;
+
     /**
      * @param \Shopware_Components_Config $config
      * @param MediaServiceInterface       $mediaService
      * @param OptimizerServiceInterface   $optimizerService
+     * @param WebpEncoderFactory          $encoderFactory
      */
-    public function __construct(\Shopware_Components_Config $config, MediaServiceInterface $mediaService, OptimizerServiceInterface $optimizerService)
-    {
+    public function __construct(
+        \Shopware_Components_Config $config,
+        MediaServiceInterface $mediaService,
+        OptimizerServiceInterface $optimizerService,
+        WebpEncoderFactory $encoderFactory
+    ) {
         $this->fixGdImageBlur = $config->get('thumbnailNoiseFilter');
         $this->mediaService = $mediaService;
         $this->optimizerService = $optimizerService;
+        $this->webpEncoderFactory = $encoderFactory;
     }
 
     /**
@@ -76,9 +89,15 @@ class WebPGenerator implements GeneratorInterface
         $this->saveImage($destination, $newImage, $quality);
         $this->optimizeImage($destination);
 
-        $webpPath = str_replace($fileExt, 'webp', $destination);
-        $this->saveWebPImage($webpPath, $newImage, $quality);
-        $this->optimizeImage($webpPath);
+        if (is_null($this->webpEncoders)) {
+            $this->webpEncoders = WebpEncoderFactory::onlyRunnable($this->webpEncoderFactory->getEncoders());
+        }
+
+        if (!empty($this->webpEncoders)) {
+            $webpPath = str_replace($fileExt, 'webp', $destination);
+            $this->mediaService->write($webpPath, $this->webpEncoders[0]->encode($newImage, $quality));
+            $this->optimizeImage($webpPath);
+        }
 
         // Removes both the original and the new created image from memory
         imagedestroy($newImage);
@@ -266,23 +285,6 @@ class WebPGenerator implements GeneratorInterface
         $this->mediaService->write($destination, $content);
     }
 
-    /**
-     * @param string $destination
-     * @param $newImage
-     * @param int $quality
-     * @return void
-     */
-    private function saveWebPImage($destination, $newImage, $quality = 80)
-    {
-        ob_start();
-
-        imagewebp($newImage, null, $quality);
-
-        $content = ob_get_contents();
-        ob_end_clean();
-
-        $this->mediaService->write($destination, $content);
-    }
 
     /**
      * @param string $destination

--- a/Components/Thumbnail/Generator/WebPGenerator.php
+++ b/Components/Thumbnail/Generator/WebPGenerator.php
@@ -95,7 +95,7 @@ class WebPGenerator implements GeneratorInterface
 
         if (!empty($this->webpEncoders)) {
             $webpPath = str_replace($fileExt, 'webp', $destination);
-            $this->mediaService->write($webpPath, $this->webpEncoders[0]->encode($newImage, $quality));
+            $this->mediaService->write($webpPath, current($this->webpEncoders)->encode($newImage, $quality));
             $this->optimizeImage($webpPath);
         }
 

--- a/Components/WebpEncoderInterface.php
+++ b/Components/WebpEncoderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ShyimWebP\Components;
+
+interface WebpEncoderInterface
+{
+    /** @return string */
+    public function getName();
+
+    /**
+     * @param resource $image
+     * @param int $quality
+     * @return string
+     */
+    public function encode($image, $quality);
+
+    /** @return bool */
+    public function isRunnable();
+}

--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ This plugin generates additional webp Thumbnails and uses is in various location
 # Installation
 
 * Checkout Plugin in `/custom/plugins/ShyimWebP`
+* Download google binaries if neccessary `php bin/console shyim:webp:download-google-binaries`
 * Generate all Thumbnails new with ``php bin/console sw:thumbnail:generate -f``

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # WebP Support for Shopware
 
-Required Minimum Shopware Version 5.3
-
 [WebP Browser-Support](http://caniuse.com/#search=webp)
 
 This plugin generates additional webp Thumbnails and uses is in various locations like detail, listing, emotion as preferred type using html5 picture tag. Browsers which does not support webp, will get normally jpg. 
 **After installation of the Plugin regenerating all thumbnails is required.**
+
+# Requirements
+
+* Shopware Version 5.3+
+* any webp encoder
+  * php-gd with webp support
+  * cwebp executable in PATH
 
 # Installation
 

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -3,6 +3,9 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="shyim_web_p.cached_download_dir">%shyim_web_p.plugin_dir%/.libwebp</parameter>
+    </parameters>
     <services>
         <service id="thumbnail_generator_basic" class="ShyimWebP\Components\Thumbnail\Generator\WebPGenerator">
             <argument type="service" id="config"/>
@@ -41,6 +44,10 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="shyim_webp.commands.download_google_binaries" class="ShyimWebP\Commands\DownloadGoogleBinaries">
+            <tag name="console.command"/>
+        </service>
+
         <service id="shyim_webp.services.webp_encoder_factory" class="ShyimWebP\Services\WebpEncoderFactory">
             <argument type="tagged" tag="shyim_webp.webp_encoder"/>
         </service>
@@ -51,6 +58,7 @@
 
         <service id="shyim_webp.services.webp_encoders.google_binary" class="ShyimWebP\Services\WebpEncoders\GoogleBinary">
             <tag name="shyim_webp.webp_encoder" priority="200" />
+            <argument type="string">%shyim_web_p.cached_download_dir%</argument>
         </service>
     </services>
 </container>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -48,5 +48,9 @@
         <service id="shyim_webp.services.webp_encoders.php_gd" class="ShyimWebP\Services\WebpEncoders\PhpGd">
             <tag name="shyim_webp.webp_encoder" priority="100" />
         </service>
+
+        <service id="shyim_webp.services.webp_encoders.google_binary" class="ShyimWebP\Services\WebpEncoders\GoogleBinary">
+            <tag name="shyim_webp.webp_encoder" priority="200" />
+        </service>
     </services>
 </container>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -4,7 +4,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="shyim_web_p.cached_download_dir">%shyim_web_p.plugin_dir%/.libwebp</parameter>
+        <parameter key="shyim_web_p.cached_download_dir">%kernel.root_dir%/var/libwebp</parameter>
     </parameters>
     <services>
         <service id="thumbnail_generator_basic" class="ShyimWebP\Components\Thumbnail\Generator\WebPGenerator">

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -48,8 +48,12 @@
             <tag name="console.command" command="shyim:webp:download-google-binaries"/>
         </service>
 
+        <service id="shyim_webp.collections.webp_encoders" class="Doctrine\Common\Collections\ArrayCollection">
+            <argument type="collection"/>
+        </service>
+
         <service id="shyim_webp.services.webp_encoder_factory" class="ShyimWebP\Services\WebpEncoderFactory">
-            <argument type="tagged" tag="shyim_webp.webp_encoder"/>
+            <argument type="service" id="shyim_webp.collections.webp_encoders"/>
         </service>
 
         <service id="shyim_webp.services.webp_encoders.php_gd" class="ShyimWebP\Services\WebpEncoders\PhpGd">

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -41,11 +41,11 @@
         </service>
 
         <service id="shyim_webp.commands.generate_webp" class="ShyimWebP\Commands\GenerateWebpImages">
-            <tag name="console.command"/>
+            <tag name="console.command" command="shyim:webp:generate"/>
         </service>
 
         <service id="shyim_webp.commands.download_google_binaries" class="ShyimWebP\Commands\DownloadGoogleBinaries">
-            <tag name="console.command"/>
+            <tag name="console.command" command="shyim:webp:download-google-binaries"/>
         </service>
 
         <service id="shyim_webp.services.webp_encoder_factory" class="ShyimWebP\Services\WebpEncoderFactory">

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="config"/>
             <argument type="service" id="shopware_media.media_service"/>
             <argument type="service" id="shopware_media.optimizer_service"/>
+            <argument type="service" id="shyim_webp.services.webp_encoder_factory"/>
         </service>
 
         <service id="shyim_webp.mediahydrator" class="ShyimWebP\Components\MediaHydrator" decorates="shopware_storefront.media_hydrator_dbal" decoration-priority="500">
@@ -38,6 +39,14 @@
 
         <service id="shyim_webp.commands.generate_webp" class="ShyimWebP\Commands\GenerateWebpImages">
             <tag name="console.command"/>
+        </service>
+
+        <service id="shyim_webp.services.webp_encoder_factory" class="ShyimWebP\Services\WebpEncoderFactory">
+            <argument type="tagged" tag="shyim_webp.webp_encoder"/>
+        </service>
+
+        <service id="shyim_webp.services.webp_encoders.php_gd" class="ShyimWebP\Services\WebpEncoders\PhpGd">
+            <tag name="shyim_webp.webp_encoder" priority="100" />
         </service>
     </services>
 </container>

--- a/Services/WebpEncoderFactory.php
+++ b/Services/WebpEncoderFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ShyimWebP\Services;
+
+use IteratorAggregate;
+use ShyimWebP\Components\WebpEncoderInterface;
+
+class WebpEncoderFactory
+{
+    /** @var WebpEncoderInterface[] */
+    private $encoders;
+
+    public function __construct(IteratorAggregate $encoders)
+    {
+        $this->encoders = iterator_to_array($encoders);
+    }
+
+    /** @return WebpEncoderInterface[] */
+    public function getEncoders()
+    {
+        return $this->encoders;
+    }
+
+    /**
+     * @param WebpEncoderInterface[] $encoders
+     * @return WebpEncoderInterface[]
+     */
+    public static function onlyRunnable(array $encoders)
+    {
+        return array_values(array_filter(
+            $encoders,
+            function (WebpEncoderInterface $encoder) {
+                return $encoder->isRunnable();
+            }
+        ));
+    }
+}

--- a/Services/WebpEncoderFactory.php
+++ b/Services/WebpEncoderFactory.php
@@ -27,11 +27,11 @@ class WebpEncoderFactory
      */
     public static function onlyRunnable(array $encoders)
     {
-        return array_values(array_filter(
+        return array_filter(
             $encoders,
             function (WebpEncoderInterface $encoder) {
                 return $encoder->isRunnable();
             }
-        ));
+        );
     }
 }

--- a/Services/WebpEncoderFactory.php
+++ b/Services/WebpEncoderFactory.php
@@ -2,7 +2,7 @@
 
 namespace ShyimWebP\Services;
 
-use IteratorAggregate;
+use Doctrine\Common\Collections\ArrayCollection;
 use ShyimWebP\Components\WebpEncoderInterface;
 
 class WebpEncoderFactory
@@ -10,9 +10,9 @@ class WebpEncoderFactory
     /** @var WebpEncoderInterface[] */
     private $encoders;
 
-    public function __construct(IteratorAggregate $encoders)
+    public function __construct(ArrayCollection $encoders)
     {
-        $this->encoders = iterator_to_array($encoders);
+        $this->encoders = $encoders->toArray();
     }
 
     /** @return WebpEncoderInterface[] */

--- a/Services/WebpEncoders/GoogleBinary.php
+++ b/Services/WebpEncoders/GoogleBinary.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ShyimWebP\Services\WebpEncoders;
+
+use ShyimWebP\Components\WebpEncoderInterface;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class GoogleBinary implements WebpEncoderInterface
+{
+    /** {@inheritdoc} */
+    public function getName()
+    {
+        return 'Google cwebp';
+    }
+
+    /** {@inheritdoc} */
+    public function encode($image, $quality)
+    {
+        $src = tempnam(sys_get_temp_dir(), 'cwebp');
+        $dst = $src . '-dst';
+
+        try {
+            imagepng($image, $src, 0);
+            $process = new Process([
+                $this->getGoogleWebpConverterPath(),
+                '-q',
+                (string) $quality,
+                $src,
+                '-o',
+                $dst,
+            ]);
+            $process->run();
+            return file_get_contents($dst);
+        } finally {
+            if (file_exists($src)) {
+                unlink($src);
+            }
+
+            if (file_exists($dst)) {
+                unlink($dst);
+            }
+        }
+    }
+
+    /** {@inheritdoc} */
+    public function isRunnable()
+    {
+        return !is_null($this->getGoogleWebpConverterPath());
+    }
+
+    /** @return string */
+    protected function getGoogleWebpConverterPath()
+    {
+        return (new ExecutableFinder())->find('cwebp');
+    }
+}

--- a/Services/WebpEncoders/GoogleBinary.php
+++ b/Services/WebpEncoders/GoogleBinary.php
@@ -30,6 +30,7 @@ class GoogleBinary implements WebpEncoderInterface
         $dst = $src . '-dst';
 
         try {
+            imagesavealpha($image, true);
             imagepng($image, $src, 0);
             $process = new Process([
                 $this->getGoogleWebpConverterPath(),

--- a/Services/WebpEncoders/GoogleBinary.php
+++ b/Services/WebpEncoders/GoogleBinary.php
@@ -8,6 +8,15 @@ use Symfony\Component\Process\Process;
 
 class GoogleBinary implements WebpEncoderInterface
 {
+    /** @var string */
+    private $cachedDownloadDir;
+
+    /** @param string $cachedDownloadDir */
+    public function __construct($cachedDownloadDir)
+    {
+        $this->cachedDownloadDir = $cachedDownloadDir;
+    }
+
     /** {@inheritdoc} */
     public function getName()
     {
@@ -52,6 +61,6 @@ class GoogleBinary implements WebpEncoderInterface
     /** @return string */
     protected function getGoogleWebpConverterPath()
     {
-        return (new ExecutableFinder())->find('cwebp');
+        return (new ExecutableFinder())->find('cwebp', null, [$this->cachedDownloadDir . DIRECTORY_SEPARATOR . 'bin']);
     }
 }

--- a/Services/WebpEncoders/PhpGd.php
+++ b/Services/WebpEncoders/PhpGd.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ShyimWebP\Services\WebpEncoders;
+
+use ShyimWebP\Components\WebpEncoderInterface;
+
+class PhpGd implements WebpEncoderInterface
+{
+    /** {@inheritdoc} */
+    public function getName()
+    {
+        return 'PHP GD';
+    }
+
+    /** {@inheritdoc} */
+    public function encode($image, $quality)
+    {
+        ob_start();
+        imagewebp($image, null, $quality);
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        return $content;
+    }
+
+    /** {@inheritdoc} */
+    public function isRunnable()
+    {
+        return function_exists('imagewebp')
+            && defined('IMG_WEBP')
+            && (imagetypes() & IMG_WEBP) === IMG_WEBP;
+    }
+}

--- a/ShyimWebP.php
+++ b/ShyimWebP.php
@@ -1,18 +1,9 @@
 <?php
 
-
 namespace ShyimWebP;
 
-
 use Shopware\Components\Plugin;
-use Shopware\Components\Plugin\Context\InstallContext;
 
 class ShyimWebP extends Plugin
 {
-    public function install(InstallContext $context)
-    {
-        if (!function_exists('imagewebp')) {
-            throw new \RuntimeException('GD is installed without webp support');
-        }
-    }
 }

--- a/ShyimWebP.php
+++ b/ShyimWebP.php
@@ -2,8 +2,24 @@
 
 namespace ShyimWebP;
 
+use Shopware\Components\DependencyInjection\Compiler\TagReplaceTrait;
 use Shopware\Components\Plugin;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ShyimWebP extends Plugin
 {
+    use TagReplaceTrait;
+
+    /** {@inheritdoc} */
+    public function build(ContainerBuilder $builder)
+    {
+        parent::build($builder);
+
+        $this->replaceArgumentWithTaggedService(
+            $builder,
+            'shyim_webp.collections.webp_encoders',
+            'shyim_webp.webp_encoder',
+            0
+        );
+    }
 }


### PR DESCRIPTION
I made an encoding strategy system to swap webp encoding by gd with [official encoding binaries](https://developers.google.com/speed/webp/docs/precompiled). Although when using these binaries you have more io traffic, it is easier to use in environments where you cannot simply recompile ext-gd with webp support.