### PR TITLE
Only generates retina source if retina sources should be generated

### DIFF
--- a/Components/MediaHydrator.php
+++ b/Components/MediaHydrator.php
@@ -201,7 +201,7 @@ class MediaHydrator extends \Shopware\Bundle\StoreFrontBundle\Gateway\DBAL\Hydra
             $thumbnail->addAttribute('webp', new Attribute([
                 'thumbnail' => new Thumbnail(
                     $this->mediaService->getUrl(str_replace($data['__media_extension'], 'webp', $row['source'])),
-                    $this->mediaService->getUrl(str_replace($data['__media_extension'], 'webp', $row['retinaSource'])),
+                    $retina === null ? null : $this->mediaService->getUrl(str_replace($data['__media_extension'], 'webp', $row['retinaSource'])),
                     $row['maxWidth'],
                     $row['maxHeight']
                 )


### PR DESCRIPTION
If you deactivate retina sources, the source-set would contain a url to a non-existing image. With this change the source-set only contains urls to existing images.